### PR TITLE
Update playback position

### DIFF
--- a/mediaplayerbackend.h
+++ b/mediaplayerbackend.h
@@ -98,6 +98,8 @@ private:
 
     QVariantList m_trackList;
 
+    QTimer m_positionTrackerTimer;
+
     bool m_repeatMode;
     bool m_randomMode;
     bool m_singleMode;
@@ -111,6 +113,7 @@ private:
     void onTrackPlaybackStarted(const mopidy::TlTrack &tlTrack);
     void onTracklistChanged();
     void onStateReceived(mopidy::PlaybackState state);
+    void onTimePositionReceived(int timePosition);
 
     // Mopidy tracklist callbacks
     void onTracksReceived(const mopidy::Tracks &tracks);


### PR DESCRIPTION
Added timer that fires every second to ask Mopidy about the current
playback position and then emits this information to media player.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>