### PR TITLE
Increase current playback position sampling

### DIFF
--- a/mediaplayerbackend.cpp
+++ b/mediaplayerbackend.cpp
@@ -54,7 +54,7 @@ MediaPlayerBackend::MediaPlayerBackend(QSharedPointer<mopidy::JsonRpcHandler> js
     m_playbackController.setJsonRpcHandler(jsonRpcHandler);
     m_tracklistController.setJsonRpcHandler(jsonRpcHandler);
 
-    m_positionTrackerTimer.setInterval(1000);
+    m_positionTrackerTimer.setInterval(500);
 
     connect(&m_positionTrackerTimer,
             &QTimer::timeout,


### PR DESCRIPTION
Decrease time for the timer that polls the current playback position to
increase sampling and improve accuracy.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>