### PR TITLE
Extract and set cover art for mp3 files

### DIFF
--- a/media_mopidy.pro
+++ b/media_mopidy.pro
@@ -7,6 +7,12 @@ PLUGIN_CLASS_NAME = MopidyMediaPlugin
 
 QT += core ivicore ivimedia multimedia websockets
 
+qtConfig(system-taglib) {
+    QMAKE_USE += taglib
+} else:qtConfig(taglib) {
+    include($$PWD/../../../3rdparty/taglib/taglib.pri)
+}
+
 TEMPLATE = lib
 
 CONFIG += c++11


### PR DESCRIPTION
Extract cover art from mp3 files and set URL to an image in track
properties.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>