### PR TITLE
Avoid using sudo in Jenkins job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && \
         git \
         locales \
         python \
-        sudo \
         unzip \
         wget \
         xz-utils
@@ -28,8 +27,6 @@ RUN ln -sf /bin/bash /bin/sh
 RUN useradd -U -m user
 RUN usermod --uid $UID user
 RUN groupmod --gid $GID user
-RUN adduser user sudo
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 USER user
 WORKDIR /home/user/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,13 +32,13 @@ node("Component") {
         stage("Install Raspberry Pi SDK") {
             sh '''
             chmod +x pelux-glibc-x86_64-*.sh
-            sudo ./pelux-glibc-x86_64-*.sh -y -d /opt/pelux-sdk-x86_64/master
+            ./pelux-glibc-x86_64-*.sh -y -d ~/opt/pelux-sdk-x86_64/
             '''
         }
 
         stage("Build with Raspberry Pi SDK") {
             sh '''
-            source /opt/pelux-sdk-x86_64/master/environment-setup-cortexa7t2hf-neon-vfpv4-pelux-linux-gnueabi
+            source ~/opt/pelux-sdk-x86_64/environment-setup-cortexa7t2hf-neon-vfpv4-pelux-linux-gnueabi
             qmake
             nice make -j $(nproc)
             '''


### PR DESCRIPTION
Install SDK in user home folder instead of /sdk and therefore avoid
using sudo.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>